### PR TITLE
Pinning cudf version to 0.10

### DIFF
--- a/utils/rapids-colab.sh
+++ b/utils/rapids-colab.sh
@@ -23,7 +23,7 @@ if [ ! -f Miniconda3-4.5.4-Linux-x86_64.sh ]; then
     conda install -y --prefix /usr/local \
       -c rapidsai-nightly/label/xgboost -c rapidsai-nightly -c nvidia -c conda-forge \
       python=3.6 cudatoolkit=10.0 \
-      cudf cuml cugraph gcsfs pynvml \
+      cudf=0.10 cuml cugraph gcsfs pynvml \
       dask-cudf dask-cuml \
       rapidsai/label/xgboost::xgboost=>0.9
       

--- a/utils/rapids-colab.sh
+++ b/utils/rapids-colab.sh
@@ -6,6 +6,8 @@ wget -nc https://github.com/rapidsai/notebooks-extended/raw/master/utils/env-che
 echo "Checking for GPU type:"
 python env-check.py
 
+RAPIDS_VERSION=${RAPIDS_VERSION:="0.10"}
+
 if [ ! -f Miniconda3-4.5.4-Linux-x86_64.sh ]; then
     echo "Removing conflicting packages, will replace with RAPIDS compatible versions"
     # remove existing xgboost and dask installs
@@ -23,7 +25,7 @@ if [ ! -f Miniconda3-4.5.4-Linux-x86_64.sh ]; then
     conda install -y --prefix /usr/local \
       -c rapidsai-nightly/label/xgboost -c rapidsai-nightly -c nvidia -c conda-forge \
       python=3.6 cudatoolkit=10.0 \
-      cudf=0.10 cuml cugraph gcsfs pynvml \
+      cudf=$RAPIDS_VERSION cuml cugraph gcsfs pynvml \
       dask-cudf dask-cuml \
       rapidsai/label/xgboost::xgboost=>0.9
       


### PR DESCRIPTION
Due to the many existing pip packages installed by default in Colab, if you try to `conda install -c rapidsai-nightly cudf` conda will likely install an older version of cudf.

Explicitly passing `cudf=0.10` fixes that and will result in installing the latest nightly for the rest of the RAPIDS packages as well.