### PR TITLE
Update NYC Taxi notebook for latest XGBoost

### DIFF
--- a/intermediate_notebooks/E2E/taxi/NYCTaxi-E2E.ipynb
+++ b/intermediate_notebooks/E2E/taxi/NYCTaxi-E2E.ipynb
@@ -310,7 +310,7 @@
     "                      kwargs=dict())\n",
     "    \n",
     "    \n",
-    "    df['is_weekend'] = (df['day_of_week']<2)\n",
+    "    df['is_weekend'] = (df['day_of_week']<2).astype(np.int32)\n",
     "    return df"
    ]
   },


### PR DESCRIPTION
Fixes issue #214 
This converts the boolean is_weekend to an int, which will work with the latest XGBoost but perform similarly to the old approach.
Tested locally and confirmed. (Have not tested on dataproc.)