### PR TITLE
[REVIEW] Adding RAPIDS <-> DLFrameworks Jupyter Notebook

### DIFF
--- a/blog_notebooks/interoperability/gpu_interop_dlframeworks.ipynb
+++ b/blog_notebooks/interoperability/gpu_interop_dlframeworks.ipynb
@@ -1,0 +1,251 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sharing is Caring: GPU Interoperability and <3 of All Frameworks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cupy as cp\n",
+    "import numpy as np\n",
+    "from numba import cuda\n",
+    "\n",
+    "# PyTorch 1.4 supports direct __cuda_array_interface__ handoff.\n",
+    "import torch\n",
+    "\n",
+    "# RFC: https://github.com/tensorflow/community/pull/180\n",
+    "# !pip install tfdlpack-gpu\n",
+    "import tfdlpack"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create GPU Arrays and Move to DL Frameworks with `__cuda_array_interface__`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Frameworks that leverage the `__cuda_array_interface__` can be seamlessly transferred from compatiable libraries (CuPy, Numba, cuSignal, etc) directly, without using an intermediate Tensor format like [DLPack](https://github.com/dmlc/dlpack)\n",
+    "\n",
+    "**CuPy <-> PyTorch**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CuPy GPU Array Pointer:  (139959965057024, False)\n",
+      "PyTorch GPU Tensor Pointer:  (139959965057024, False)\n",
+      "CuPy GPU Pointer:  (139959965057024, False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CuPy - GPU Array (like NumPy!)\n",
+    "gpu_arr = cp.random.rand(10_000, 10_000)\n",
+    "\n",
+    "# Look at pointer\n",
+    "print('CuPy GPU Array Pointer: ', gpu_arr.__cuda_array_interface__['data'])\n",
+    "\n",
+    "# Migrate from CuPy to PyTorch\n",
+    "torch_arr = torch.as_tensor(gpu_arr, device='cuda')\n",
+    "\n",
+    "# Look at pointer -- it's the same as the CuPy array above!\n",
+    "print('PyTorch GPU Tensor Pointer: ', torch_arr.__cuda_array_interface__['data'])\n",
+    "\n",
+    "# Migrate from PyTorch to CuPy\n",
+    "cupy_arr = cp.asarray(torch_arr)\n",
+    "\n",
+    "# Look at pointer\n",
+    "print('CuPy GPU Pointer: ', cupy_arr.__cuda_array_interface__['data'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Numba CUDA <-> PyTorch**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Numba GPU Array Pointer:  (139958354444288, False)\n",
+      "PyTorch GPU Tensor Pointer:  (139958354444288, False)\n",
+      "Numba GPU Pointer:  (139958354444288, False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NumPy - CPU Array\n",
+    "cpu_arr = np.random.rand(10_000, 10_000)\n",
+    "\n",
+    "# Use Numba to move to GPU\n",
+    "numba_gpu_arr = cuda.to_device(cpu_arr)\n",
+    "\n",
+    "# Migrate from Numba, used for custom CUDA JIT kernels to PyTorch\n",
+    "torch_arr_numba = torch.as_tensor(numba_gpu_arr, device='cuda')\n",
+    "\n",
+    "# Migrate from PyTorch back to Numba\n",
+    "numba_arr_from_torch = cuda.to_device(torch_arr_numba)\n",
+    "\n",
+    "# Pointer love again\n",
+    "print('Numba GPU Array Pointer: ', numba_gpu_arr.__cuda_array_interface__['data'])\n",
+    "print('PyTorch GPU Tensor Pointer: ', torch_arr_numba.__cuda_array_interface__['data'])\n",
+    "print('Numba GPU Pointer: ', numba_arr_from_torch.__cuda_array_interface__['data'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create GPU Arrays and Move to DL Frameworks with DLPack"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not all major frameworks currently support the `__cuda_array_interface__`, cough, [TensorFlow](https://www.tensorflow.org/). We can use the aforementioned DLPack as a bridge between the GPU ecosystem and TensorFlow with `tfdlpack`. See [this RFC](https://github.com/tensorflow/community/pull/180) for more information.\n",
+    "\n",
+    "Allow GPU growth in TensorFlow or TF will take over the entire GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!export TF_FORCE_GPU_ALLOW_GROWTH=false"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**CuPy -> TensorFlow**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/job:localhost/replica:0/task:0/device:GPU:0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CuPy - GPU Array (like NumPy!)\n",
+    "gpu_arr = cp.random.rand(10_000, 10_000)\n",
+    "\n",
+    "# Use CuPy's built in `toDlpack` function to move to a DLPack capsule\n",
+    "dlpack_arr = gpu_arr.toDlpack()\n",
+    "\n",
+    "# Use `tfdlpack` to migrate to TensorFlow\n",
+    "tf_tensor = tfdlpack.from_dlpack(dlpack_arr)\n",
+    "\n",
+    "# Confirm TF tensor is on GPU\n",
+    "print(tf_tensor.device)\n",
+    "\n",
+    "# Use `tfdlpack` to migrate back to CuPy\n",
+    "# !! Warning, this currently segfaults: https://github.com/VoVAllen/tf-dlpack/issues/12\n",
+    "# dlpack_capsule = tfdlpack.to_dlpack(tf_tensor)\n",
+    "# cupy_arr = cp.asarray(dlpack_capsule.fromDlpack())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Numba CUDA -> TensorFlow**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/job:localhost/replica:0/task:0/device:GPU:0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reset CUDA memory\n",
+    "cuda.close()\n",
+    "\n",
+    "# NumPy - CPU Array\n",
+    "cpu_arr = np.random.rand(10_000, 10_000)\n",
+    "\n",
+    "# Use Numba to move to GPU\n",
+    "numba_gpu_arr = cuda.to_device(cpu_arr)\n",
+    "\n",
+    "# Use CuPy's asarray function and toDlpack to create DLPack capsule. There are multiple other ways to do this (i.e. PyTorch Utils)\n",
+    "dlpack_arr = cp.asarray(numba_gpu_arr).toDlpack()\n",
+    "\n",
+    "# Migrate from Numba, used for custom CUDA JIT kernels to PyTorch\n",
+    "tf_tensor = tfdlpack.from_dlpack(dlpack_arr)\n",
+    "\n",
+    "# Confirm TF tensor is on GPU\n",
+    "print(tf_tensor.device)\n",
+    "\n",
+    "# Use `tfdlpack` to migrate back to CuPy\n",
+    "# !! Warning, this currently segfaults: https://github.com/VoVAllen/tf-dlpack/issues/12\n",
+    "# dlpack_capsule = tfdlpack.to_dlpack(tf_tensor)\n",
+    "# numba_arr = cuda.to_device(dlpack_capsule.fromDlpack())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This notebook shows how to pass data between `__cuda_array_interface__` supporting libraries (CuPy and Numba, for this demonstration) and both PyTorch and TensorFlow. When using PyTorch, we can simply call:

`torch.as_tensor(foo)` on an existing array that accepts the `__cuda_array_interface__` but for TensorFlow, we leverage the nascent `tfdlpack` package described in [this RFC](https://github.com/tensorflow/community/pull/180).

There is a bug in tfdlpack.to_dlpack() that is documented here: https://github.com/VoVAllen/tf-dlpack/issues/12 and also in this notebook.
